### PR TITLE
[2022-10-28] Longest Common Prefix Swift

### DIFF
--- a/ Longest Common Prefix/LongestCommonPrefix.swift
+++ b/ Longest Common Prefix/LongestCommonPrefix.swift
@@ -1,0 +1,32 @@
+import UIKit
+import Foundation
+
+class Solution {
+    func longestCommonPrefix(_ strs: [String]) -> String {
+        if strs == [] { return "" }
+        
+        var prefixStr: String = strs.min(by: { $0.count < $1.count })!
+        var temp: String = ""
+        
+        for str in strs {
+            for (index, ch) in prefixStr.enumerated() {
+                let ch = String(ch)
+                
+                if index == 0 && !str.starts(with: ch) { return "" }
+               
+                let checker = temp + ch
+                if !str.starts(with: checker) { break }
+                
+                temp = checker
+            }
+            
+            prefixStr = temp
+            temp = ""
+        }
+        
+        return prefixStr
+    }
+}
+
+let solution = Solution()
+print(solution.longestCommonPrefix(["flower","flow","flight"]))

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@
 * 2022-10-27
   * [Jieun Kim](https://github.com/saranghe41) - [Roman to Integer Swift](https://github.com/ODOA-Project/ODOA/pull/9) [✅]
   * [MINT](https://github.com/kyu1204) - [LFU Cache Python](https://github.com/ODOA-Project/ODOA/pull/10) [✅]
+* 2022-10-28
+  * [Jieun Kim](https://github.com/saranghe41) - [Longest Common Prefix Swift](https://github.com/ODOA-Project/ODOA/pull/12) [✅]
+


### PR DESCRIPTION
## Longest Common Prefix
Write a function to find the longest common prefix string amongst an array of strings.
If there is no common prefix, return an empty string "".

## Time Complex & Space Complex
Runtime: 150 ms, faster than 11.62% of Swift online submissions for Longest Common Prefix.
Memory Usage: 14.4 MB, less than 44.86% of Swift online submissions for Longest Common Prefix.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/longest-common-prefix/)

## 기타 사항
새벽 3시까지 하다니.... 도와줘서 고마워 🫶
