### PR TITLE
[2022-11-02] Remove Element Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@
 * 2022-11-01
   * [MINT](https://github.com/kyu1204) - [Remove Duplicates from Sorted Array Python](https://github.com/ODOA-Project/ODOA/pull/13) [✅]
   * [Jieun Kim](https://github.com/saranghe41) - [Valid Parentheses Swift](https://github.com/ODOA-Project/ODOA/pull/14) [✅]
+* 2022-11-02
+  * [yourHooni](https://github.com/yourHooni) - [Remove Element Python](https://github.com/ODOA-Project/ODOA/pull/15) [✅]

--- a/Remove Element/remove_element.py
+++ b/Remove Element/remove_element.py
@@ -1,0 +1,21 @@
+from typing import List
+
+class Solution:
+    def removeElement(self, nums: List[int], val: int) -> int:
+        while val in nums:
+            nums.remove(val)
+        return len(nums)
+
+if __name__ == "__main__":
+    _nums = [0,1,2,2,3,0,4,2]
+    _val = 2
+    expected_nums = [0, 0, 1, 3, 4]
+
+    result = Solution().removeElement(_nums, _val)
+
+    assert result == len(expected_nums)
+    _nums.sort()
+    for idx in range(len(_nums)):
+        assert _nums[idx] == expected_nums[idx]
+
+

--- a/Remove Element/remove_element.py
+++ b/Remove Element/remove_element.py
@@ -2,8 +2,7 @@ from typing import List
 
 class Solution:
     def removeElement(self, nums: List[int], val: int) -> int:
-        while val in nums:
-            nums.remove(val)
+        nums[:] = [num for num in nums if num != val]
         return len(nums)
 
 if __name__ == "__main__":
@@ -18,4 +17,14 @@ if __name__ == "__main__":
     for idx in range(len(_nums)):
         assert _nums[idx] == expected_nums[idx]
 
+
+# 포인터
+# python에서 immutable 객체(int, float, str, tuple - 수정 불가능한 객체)에 새로운 값이 할당될 때, 새로운 메모리 공간에 값이 할당된다.
+# 즉, 다른 함수에서 값을 변경시에 참조되지 않은 상태로 새로운 매모리에 할당되므로 python Reference count에 의해 메모리에서 삭제될 확률이 크다.
+# mutable(list, dict - 수정 가능한 객체) 객체의 값은 기존 메모리를 사용하며 변경이 가능하다. ex) list[:] = new_list
+# 단, 새로운 값을 할당시에는 새로운 메모리가 할당됨. ex) list = new_list
+
+# ** reference count: 참조하는 객체의 개수
+# sys.getrefcount(객체): reference count 개수 체크
+# if reference count == 0 -> 삭제 대상이 되며 메모리 할당 해제
 


### PR DESCRIPTION
## Remove Element
Given an integer array nums and an integer val, remove all occurrences of val in nums [in-place](https://en.wikipedia.org/wiki/In-place_algorithm). The relative order of the elements may be changed.

Since it is impossible to change the length of the array in some languages, you must instead have the result be placed in the first part of the array nums. More formally, if there are k elements after removing the duplicates, then the first k elements of nums should hold the final result. It does not matter what you leave beyond the first k elements.

Return k after placing the final result in the first k slots of nums.

Do not allocate extra space for another array. You must do this by modifying the input array [in-place](https://en.wikipedia.org/wiki/In-place_algorithm) with O(1) extra memory.

## Time Complex & Space Complex
Runtime: 39 ms, faster than 87.81% of Python3 online submissions for Remove Element.
Memory Usage: 13.8 MB, less than 97.27% of Python3 online submissions for Remove Element.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/remove-element/)

## 기타 사항
* 초기에 remove 함수를 이용했으나 속도를 증진시키기 위해 로직 변경.
* python 포인터 관련해서 다시 살펴봄!
