### PR TITLE
[2022-11-03] Remove Duplicates from Sorted Array Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@
 * 2022-11-03
   * [kyeongmi](https://github.com/lim-km) - [Roman to Integer C++](https://github.com/ODOA-Project/ODOA/pull/18) [✅]
   * [MINT](https://github.com/kyu1204) - [Search Insert Position Python](https://github.com/ODOA-Project/ODOA/pull/22) [✅]
+  * [Jieun Kim](https://github.com/saranghe41) - [Remove Duplicates from Sorted Array](https://github.com/ODOA-Project/ODOA/pull/21) [✅]

--- a/Remove Duplicates from Sorted Array/Remove_Duplicates_from_Sorted_Array.swift
+++ b/Remove Duplicates from Sorted Array/Remove_Duplicates_from_Sorted_Array.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class Solution {
+    func removeDuplicates(_ nums: inout [Int]) -> Int {
+        nums = Array(Set<Int>(nums)).sorted()
+        return nums.count
+    }
+}
+
+let solution = Solution()
+var num = [1, 1, 2]
+solution.removeDuplicates(&num)
+


### PR DESCRIPTION
## Remove Duplicates from Sorted Array
Given an integer array nums sorted in non-decreasing order, remove the duplicates [in-place](https://en.wikipedia.org/wiki/In-place_algorithm) such that each unique element appears only once. The relative order of the elements should be kept the same.
Since it is impossible to change the length of the array in some languages, you must instead have the result be placed in the first part of the array nums. More formally, if there are k elements after removing the duplicates, then the first k elements of nums should hold the final result. It does not matter what you leave beyond the first k elements.
Return k after placing the final result in the first k slots of nums.
Do not allocate extra space for another array. You must do this by modifying the input array [in-place](https://en.wikipedia.org/wiki/In-place_algorithm) with O(1) extra memory.

## Time Complex & Space Complex
Runtime: 163 ms, faster than 23.57% of Swift online submissions for Remove Duplicates from Sorted Array.
Memory Usage: 15 MB, less than 40.83% of Swift online submissions for Remove Duplicates from Sorted Array.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/remove-duplicates-from-sorted-array/submissions/)

## 기타 사항
* 메모리를 추가 할당하지 않고 풀려니 생각이 막혔었는데, 단순히 Set화 시켜서 간단하게 해결 가능했다.🤯
