### PR TITLE
[2022-11-04] Longest Common Prefix Python

### DIFF
--- a/Flood Fill/flood_fill.py
+++ b/Flood Fill/flood_fill.py
@@ -1,0 +1,48 @@
+from typing import List
+
+
+class Solution:
+    def fill(self, image: List[List[int]], color: int, init_value: int, sr: int, sc: int):
+        if image[sr][sc] != init_value:
+            return
+
+        image[sr][sc] = color
+
+        if sr > 0:
+            self.fill(image, color, init_value, sr - 1, sc)
+        if sc > 0:
+            self.fill(image, color, init_value, sr, sc - 1)
+        if sr < len(image) - 1:
+            self.fill(image, color, init_value, sr + 1, sc)
+        if sc < len(image[0]) - 1:
+            self.fill(image, color, init_value, sr, sc + 1)
+
+    def floodFill(self, image: List[List[int]], sr: int, sc: int, color: int) -> List[List[int]]:
+        if image[sr][sc] != color:
+            self.fill(image, color, image[sr][sc], sr, sc)
+
+        return image
+
+
+if __name__ == "__main__":
+    cases = [
+        {
+            "image": [[1, 1, 1], [1, 1, 0], [1, 0, 1]],
+            "sr": 1,
+            "sc": 1,
+            "color": 2,
+            "result": [[2, 2, 2], [2, 2, 0], [2, 0, 1]]
+        },
+        {
+            "image": [[0, 0, 0], [0, 0, 0]],
+            "sr": 0,
+            "sc": 0,
+            "color": 0,
+            "result": [[0, 0, 0], [0, 0, 0]]
+        }
+    ]
+
+    for case in cases:
+        result = Solution().floodFill(case["image"], case["sr"], case["sc"], case["color"])
+        print("result", result)
+        assert result == case["result"]

--- a/Longest Common Prefix/longest_common_prefix.py
+++ b/Longest Common Prefix/longest_common_prefix.py
@@ -1,0 +1,31 @@
+from typing import List
+
+
+class Solution:
+    def longestCommonPrefix(self, strs: List[str]) -> str:
+        prefix = strs[0]
+
+        for str_v in strs:
+            for i, c in enumerate(prefix):
+                if len(str_v) - 1 < i or str_v[i] != c:
+                    prefix = prefix[:i]
+                    break
+        return prefix
+
+
+if __name__ == "__main__":
+    cases = [
+        {
+            "strs": ["flower", "flow", "flight"],
+            "result": "fl"
+        },
+        {
+            "strs": ["dog", "racecar", "car"],
+            "result": ""
+        }
+    ]
+
+    for case in cases:
+        result = Solution().longestCommonPrefix(case["strs"])
+        print("result", result)
+        assert result == case["result"]

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@
   * [yourHooni](https://github.com/yourHooni) - [Valid Perfect Square Python](https://github.com/ODOA-Project/ODOA/pull/17) [✅]
 * 2022-11-03
   * [kyeongmi](https://github.com/lim-km) - [Roman to Integer C++](https://github.com/ODOA-Project/ODOA/pull/18) [✅]
+  * [yourHooni](https://github.com/yourHooni) - [Remove Element Python](https://github.com/ODOA-Project/ODOA/pull/24) [✅]
 * 2022-11-04
   * [yourHooni](https://github.com/yourHooni) - [Longest Common Prefix Python](https://github.com/ODOA-Project/ODOA/pull/26) [✅]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@
   * [yourHooni](https://github.com/yourHooni) - [Valid Perfect Square Python](https://github.com/ODOA-Project/ODOA/pull/17) [✅]
 * 2022-11-03
   * [kyeongmi](https://github.com/lim-km) - [Roman to Integer C++](https://github.com/ODOA-Project/ODOA/pull/18) [✅]
+* 2022-11-04
+  * [yourHooni](https://github.com/yourHooni) - [Longest Common Prefix Python](https://github.com/ODOA-Project/ODOA/pull/26) [✅]


### PR DESCRIPTION
## Longest Common Prefix
Write a function to find the longest common prefix string amongst an array of strings.

If there is no common prefix, return an empty string "".

## Time Complex & Space Complex
Runtime: 55 ms, faster than 72.96% of Python3 online submissions for Longest Common Prefix.
Memory Usage: 13.8 MB, less than 88.32% of Python3 online submissions for Longest Common Prefix.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/longest-common-prefix/)

## 기타 사항
* 이중 포문을 사용하지 않는 방법을 고민해봤으나 생각해내지 못함..
* slice를 최소로 사용하도록 고려
