### PR TITLE
[2022-11-11] Length of Last Word Swift

### DIFF
--- a/Length of Last Word/Length_of_Last_Word.swift
+++ b/Length of Last Word/Length_of_Last_Word.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+class Solution {
+    func lengthOfLastWord(_ s: String) -> Int {
+        let str = s.split(separator: " ")
+            .filter { $0 != "" }
+            .map { $0 }
+            .last ?? ""
+        
+        return str.count
+    }
+}
+
+let solution = Solution()
+solution.lengthOfLastWord("   fly me   to   the moon  ")

--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@
   * [kyeongmi](https://github.com/lim-km) - [Longest Common Prefix C++](https://github.com/ODOA-Project/ODOA/pull/23) [✅]
 * 2022-11-04
   * [Jieun Kim](https://github.com/saranghe41) - [Remove Element](https://github.com/ODOA-Project/ODOA/pull/28) [✅]
+* 2022-11-11
+  * [Jieun Kim](https://github.com/saranghe41) - [Length of Last Word](https://github.com/ODOA-Project/ODOA/pull/33) [✅]


### PR DESCRIPTION
## Length of Last Word
Given a string s consisting of words and spaces, return the length of the last word in the string.
A word is a maximal substring consisting of non-space characters only.

## Time Complex & Space Complex
Runtime: 4 ms, faster than 79.23% of Swift online submissions for Length of Last Word.
Memory Usage: 14.2 MB, less than 69.76% of Swift online submissions for Length of Last Word.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/length-of-last-word/)

## 기타 사항
* string을 쪼개는 함수로 components(), split()가 있다.
* split()는 charater 타입에서 사용할 수 있어, map 고차함수를 사용해주어야 한다.
