### PR TITLE
[2022-11-14] Add binary Swift

### DIFF
--- a/Add Binary/Add_Binary.swift
+++ b/Add Binary/Add_Binary.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+class Solution {
+    func addBinary(_ a: String, _ b: String) -> String {
+        let a = String(repeating: "0", count: max(0, b.count - a.count)) + a
+        let b = String(repeating: "0", count: max(0, a.count - b.count)) + b
+        
+        var result = ""
+        var carry = 0
+        
+        for (a, b) in zip(a.reversed(), b.reversed()) {
+            let a = Int(String(a)) ?? 0
+            let b = Int(String(b)) ?? 0
+            let sum = a + b + carry
+            result = String(sum % 2) + result
+            carry = sum / 2
+        }
+                          
+        if carry == 1 { result = "1" + result }
+        
+        return result
+    }
+}
+
+let solution = Solution()
+solution.addBinary("11", "1")

--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@
   * [kyeongmi](https://github.com/lim-km) - [Merge Two Sorted Lists C++](https://github.com/ODOA-Project/ODOA/pull/30) [✅]
 * 2022-11-08
   * [MINT](https://github.com/kyu1204) - [Merge Sorted Array Python](https://github.com/ODOA-Project/ODOA/pull/31) [✅]
+* 2022-11-14
+  * [Jieun Kim](https://github.com/saranghe41) - [Add Binary](https://github.com/ODOA-Project/ODOA/pull/38) [✅]


### PR DESCRIPTION
## Add Binary
Given two binary strings a and b, return their sum as a binary string.

## Time Complex & Space Complex
Runtime: 14 ms, faster than 69.77% of Swift online submissions for Add Binary.
Memory Usage: 14.4 MB, less than 48.84% of Swift online submissions for Add Binary.

## 참고 링크
* [Leet Code](https://leetcode.com/problems/add-binary/)

## 기타 사항
* reserved() 처리까지 하다가 막혔다.
* 답지 참고하여 a, b 두 string의 길이를 맞춰 계산완료.
* 생각의 발상을 다르게 할 필요를 또 느꼈다.
